### PR TITLE
Fix napi targets for all binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "napi": {
     "binaryName": "i18n-scanner-rs",
     "targets": [
-      "aarch64-apple-darwin"
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-pc-windows-msvc"
     ]
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary
- update the napi targets list to include every packaged platform so artifact moves succeed

## Testing
- pnpm run build *(fails: registry.npmjs.org returned 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5634660a88328924bb552b1f6b0b8