### PR TITLE
Fix CI Linux build by installing newer GCC

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,10 @@ jobs:
             build: |-
               npm install -g corepack@latest
               rustup update
-              apt-get install gcc-10.2 g++-10.2
+              apt-get update
+              apt-get install -y --no-install-recommends gcc-12 g++-12
+              update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 120
+              update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 120
               pnpm build --target x86_64-unknown-linux-gnu --use-napi-cross
           - host: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary
- update the Linux Docker build step to install GCC/G++ 12
- ensure the newer compiler is selected via update-alternatives before building bindings

## Testing
- not run (CI only change)


------
https://chatgpt.com/codex/tasks/task_e_68da07cde4048328afab224861011bb4