### PR TITLE
Add custom i18n workspace support and tests

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - '.'
+  - 'tests/custom-i18n'

--- a/src/analyzer/analyzer.rs
+++ b/src/analyzer/analyzer.rs
@@ -98,7 +98,10 @@ impl Analyzer {
 
 #[cfg(test)]
 mod tests {
-  use crate::analyzer::test_utils::{analyze, make_extend_packages};
+  use crate::analyzer::test_utils::{
+    analyze, make_custom_i18n_package, make_extend_packages, test_path,
+  };
+  use std::path::Path;
 
   #[test]
   fn make_seed() {
@@ -121,6 +124,29 @@ mod tests {
     let (_, node_store) = analyze("index.tsx".into(), Some(pkgs));
 
     assert_eq!(node_store.get_i18n_exported_nodes().len(), 4);
+  }
+
+  #[test]
+  fn extended_custom_package_is_seeded() {
+    let pkgs = make_custom_i18n_package();
+
+    let (analyzer, node_store) = analyze("CustomI18n.tsx".into(), Some(pkgs));
+
+    let entry_path = test_path("CustomI18n.tsx");
+    let base = Path::new(&entry_path).parent().unwrap();
+    let resolved = analyzer
+      .resolver
+      .resolve(base, "@custom/i18n")
+      .expect("custom package should resolve");
+
+    let resolved_path = resolved.path().to_str().expect("path to str");
+
+    let has_custom_package = node_store
+      .get_i18n_exported_nodes()
+      .iter()
+      .any(|(path, _)| path.as_str() == resolved_path);
+
+    assert!(has_custom_package, "custom package should be seeded");
   }
 
   #[test]

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,6 +1,7 @@
 pub mod analyzer;
 pub mod i18n_packages;
 pub mod resolver;
+#[cfg(test)]
 pub mod test_utils;
 mod visit;
 mod walker;

--- a/src/analyzer/test_utils.rs
+++ b/src/analyzer/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::analyzer::analyzer::Analyzer;
-use crate::analyzer::i18n_packages::{I18nPackage, Member};
+use crate::analyzer::i18n_packages::{I18nPackage, Member, PRESET_I18N_MEMBERS};
 use crate::node::i18n_types::I18nType;
 use crate::node::node_store::NodeStore;
 use fs::canonicalize;
@@ -39,5 +39,19 @@ pub fn make_extend_packages() -> Vec<I18nPackage> {
       name: "useFeTranslation".to_string(),
       ns: Some("namespace_3".into()),
     }],
+  }]
+}
+
+pub fn make_custom_i18n_package() -> Vec<I18nPackage> {
+  vec![I18nPackage {
+    package_path: "@custom/i18n".into(),
+    members: PRESET_I18N_MEMBERS
+      .iter()
+      .map(|(name, r#type)| Member {
+        name: name.to_string(),
+        r#type: r#type.clone(),
+        ns: None,
+      })
+      .collect(),
   }]
 }

--- a/src/collector/collector.rs
+++ b/src/collector/collector.rs
@@ -70,6 +70,7 @@ impl Collector {
 
 #[cfg(test)]
 mod tests {
+  use crate::analyzer::test_utils::make_custom_i18n_package;
   use crate::collector::test_utils::collect;
   use crate::key_match;
 
@@ -85,6 +86,14 @@ mod tests {
     assert_eq!(collector.get_keys("namespace_1").len(), 2);
     assert_eq!(collector.get_keys("namespace_2").len(), 1);
     assert_eq!(collector.get_keys("namespace_3").len(), 2);
+  }
+
+  #[test]
+  fn full_collect_with_custom_package() {
+    let (_, collector) = collect("index.tsx".into(), Some(make_custom_i18n_package()));
+
+    assert_eq!(collector.i18n_namespaces.len(), 5);
+    assert_eq!(collector.get_keys("custom_namespace").len(), 3);
   }
 
   key_match!(
@@ -177,6 +186,18 @@ mod tests {
   );
 
   key_match!(hoc_component, "HocComp.tsx".into(), vec!["HOC_COMPONENT"]);
+
+  key_match!(
+    custom_i18n_usage,
+    "CustomI18n.tsx".into(),
+    "custom_namespace".into(),
+    make_custom_i18n_package(),
+    vec![
+      "CUSTOM_GLOBAL_T",
+      "CUSTOM_HOOK_KEY",
+      "CUSTOM_HOOK_KEY_AGAIN"
+    ]
+  );
 
   key_match!(
     trans_component,

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,5 +1,6 @@
 pub mod collector;
 mod post_collector;
+#[cfg(test)]
 pub mod test_utils;
 mod visit;
 mod walker;

--- a/tests/custom-i18n/index.d.ts
+++ b/tests/custom-i18n/index.d.ts
@@ -1,0 +1,14 @@
+export interface TFunction {
+  (key: string, options?: { ns?: string }): unknown;
+}
+
+export interface UseTranslationResult {
+  t: TFunction;
+}
+
+export declare function useTranslation(ns?: string): UseTranslationResult;
+export declare const t: TFunction;
+export declare function withTranslation(ns?: string): (Component: unknown) => unknown;
+export declare const Trans: unknown;
+export declare const Translation: unknown;
+export declare const i18n: { t: TFunction };

--- a/tests/custom-i18n/index.js
+++ b/tests/custom-i18n/index.js
@@ -1,0 +1,25 @@
+const createT = (ns) => (key, options = {}) => ({ key, ns: options.ns ?? ns ?? 'default' });
+
+const useTranslation = (ns) => ({
+  t: createT(ns),
+});
+
+const t = createT();
+
+const withTranslation = (ns) => (Component) => Component;
+
+const Trans = () => null;
+const Translation = ({ children }) => (typeof children === 'function' ? children(createT()) : null);
+
+const i18n = {
+  t,
+};
+
+module.exports = {
+  useTranslation,
+  t,
+  withTranslation,
+  Trans,
+  Translation,
+  i18n,
+};

--- a/tests/custom-i18n/package.json
+++ b/tests/custom-i18n/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@custom/i18n",
+  "version": "0.0.0",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "private": true
+}

--- a/tests/fake-project/src/CustomI18n.tsx
+++ b/tests/fake-project/src/CustomI18n.tsx
@@ -1,0 +1,16 @@
+import { useTranslation, t as globalCustomT } from '@custom/i18n';
+
+const CustomI18n = () => {
+  const { t } = useTranslation('custom_namespace');
+
+  const customGlobal = globalCustomT('CUSTOM_GLOBAL_T', { ns: 'custom_namespace' });
+
+  return (
+    <>
+      {t('CUSTOM_HOOK_KEY')}
+      {customGlobal && t('CUSTOM_HOOK_KEY_AGAIN')}
+    </>
+  );
+};
+
+export default CustomI18n;

--- a/tests/fake-project/src/index.tsx
+++ b/tests/fake-project/src/index.tsx
@@ -20,6 +20,7 @@ import TWithNamespace from './TWithNamespace';
 import NamespaceOverride from './NamespaceOverride';
 import { memberT } from './memberT';
 import NamespaceFromVar from './NamespaceFromVar';
+import CustomI18n from './CustomI18n';
 
 init();
 
@@ -47,6 +48,7 @@ const Entry = () => {
       <MemberCallT />
       <NamespaceImport />
       <I18nCodeCrossFile />
+      <CustomI18n />
     </>
   );
 };

--- a/tests/fake-project/tsconfig.json
+++ b/tests/fake-project/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "jsx": "preserve",
     "baseUrl": ".",
-    "paths": {}
+    "paths": {
+      "@custom/i18n": ["../custom-i18n/index"],
+      "@custom/i18n/*": ["../custom-i18n/*"]
+    }
   },
   "include": ["src"]
 }

--- a/tests/tests.spec.ts
+++ b/tests/tests.spec.ts
@@ -1,9 +1,22 @@
 import {describe, it, expect} from "vitest";
-import {scan} from '../index'
+import {scan, I18nType} from '../index'
 import * as path from 'node:path'
 
 const root = path.join(__dirname, './fake-project');
 const tsconfigPath = path.join(root, 'tsconfig.json');
+const extendPackages = [
+    {
+        packagePath: '@custom/i18n',
+        members: [
+            {name: 'useTranslation', type: I18nType.Hook},
+            {name: 't', type: I18nType.TMethod},
+            {name: 'Trans', type: I18nType.TransComp},
+            {name: 'Translation', type: I18nType.TranslationComp},
+            {name: 'withTranslation', type: I18nType.HocWrapper},
+            {name: 'i18n', type: I18nType.ObjectMemberT},
+        ],
+    },
+];
 
 describe("I18n-scanner-rs", () => {
     it('Should collect matched snapshot', () => {
@@ -11,10 +24,16 @@ describe("I18n-scanner-rs", () => {
             entryPaths: [path.join(root, './src/index.tsx')],
             tsconfigPath,
             externals: [],
+            extendI18NPackages: extendPackages,
         });
         const sortedResult = Object.fromEntries(Object.entries(result).map(([k, v]) => [k, v.sort()]));
         expect(sortedResult).toMatchInlineSnapshot(`
           {
+            "custom_namespace": [
+              "CUSTOM_GLOBAL_T",
+              "CUSTOM_HOOK_KEY",
+              "CUSTOM_HOOK_KEY_AGAIN",
+            ],
             "default": [
               "GLOBAL_T",
               "HOC_COMPONENT",


### PR DESCRIPTION
## Summary
- add a pnpm workspace and a local `@custom/i18n` fixture package to simulate extending presets
- update the fake project plus analyzer and collector tests to cover the custom package and ensure it is seeded
- refresh the Vitest snapshot to include keys collected from the custom package usage

## Testing
- `cargo test`
- `NAPI_RS_NATIVE_LIBRARY_PATH=$(pwd)/i18n-scanner-rs.linux-x64-gnu.node pnpm test -u`
- `NAPI_RS_NATIVE_LIBRARY_PATH=$(pwd)/i18n-scanner-rs.linux-x64-gnu.node pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68dc9cb61a4c83289947c199d38f0630